### PR TITLE
fix for centre positioning

### DIFF
--- a/pixi-multistyle-text.js
+++ b/pixi-multistyle-text.js
@@ -273,7 +273,7 @@ MultiStyleText.prototype.updateText = function()
             if(this.style.align === 'right') {
                 linePositionX += maxLineWidth - lineWidths[i];
             }
-            else if(this.style.align === 'center')
+            else if(this.style.align === 'center' && linePositionX === 0)
             {
                 linePositionX += (maxLineWidth - lineWidths[i]) / 2;
             }


### PR DESCRIPTION
When you have multiline text if first line is shorter then other lines
then it will be out of position because line width is added twice at the
centering point and at the end of for loop for adding previous segment.
This small fix fixed that issue :)

