### PR TITLE
Fix for breaking style when style is in multiline

### DIFF
--- a/pixi-multistyle-text.js
+++ b/pixi-multistyle-text.js
@@ -160,7 +160,7 @@ MultiStyleText.prototype._getTextDataPerLine = function(lines) {
             if(currentSearchIdx < lines[i].length) {
                 lineTextData.push({
                     text: lines[i].substring(currentSearchIdx),
-                    style: this.textStyles.def
+                    style: currentStyle
                 });
             }
         }


### PR DESCRIPTION
There is an issue #2 that breaks style when the ending tag for style is
on the separate line.