### PR TITLE
[Fixes #11] Fix line y-position computation bug

### DIFF
--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -225,6 +225,8 @@ class MultiStyleText extends PIXI.Text {
 		this.context.textBaseline = "alphabetic";
 		this.context.lineJoin = "round";
 
+		let basePositionY = 0;
+
 		// Draw the text
 		for (let i = 0; i < outputTextData.length; i++) {
 			let line = outputTextData[i];
@@ -246,7 +248,7 @@ class MultiStyleText extends PIXI.Text {
 				this.context.lineWidth = textStyle.strokeThickness;
 
 				linePositionX += maxStrokeThickness / 2;
-				let linePositionY = (maxStrokeThickness / 2 + i * lineHeights[i]) + fontProperties.ascent;
+				let linePositionY = (maxStrokeThickness / 2 + basePositionY) + fontProperties.ascent;
 
 				if (this._style.align === "right") {
 					linePositionX += maxLineWidth - lineWidths[i];
@@ -308,6 +310,8 @@ class MultiStyleText extends PIXI.Text {
 				linePositionX += line[j].width;
 				linePositionX -= maxStrokeThickness / 2;
 			}
+
+			basePositionY += lineHeights[i];
 		}
 
 		this.updateTexture();


### PR DESCRIPTION
Removes the assumption that all lines have the same height in y-offset computation.

Post-fix screenshot:

<img width="604" alt="screenshot 2016-12-31 11 13 40" src="https://cloud.githubusercontent.com/assets/1878074/21578351/cc09e8c6-cf4a-11e6-99ba-3f065a224f85.png">


(Ignore the word-wrapping issue; I've already reported in #16 and is a distinct issue from what this PR is trying to fix.)