### PR TITLE
[Fixes #12] Add Browserify to build

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
 		var stage = new PIXI.Container();
 
 		// create some white text using the Snippet webfont
-		var textSample = new MultiStyleText.MultiStyleText("<pixi>Pixi.js</pixi> can has <multiline>multiline</multiline>\nand <multistyle>multi-styles</multistyle> text!",
+		var textSample = new MultiStyleText("<pixi>Pixi.js</pixi> can has <multiline>multiline</multiline>\nand <multistyle>multi-styles</multistyle> text!",
 			{
 				default: { fontFamily: "Tahoma", fontSize: "35px", fill: "white" },
 				multiline: { fill: "blue" },
@@ -38,7 +38,7 @@
 		textSample.position.x = 20;
 		textSample.position.y = 20;
 
-		var nested = new MultiStyleText.MultiStyleText("(<a>Now with <b>support</b> for <c>nesting <d>tags</d></c>!  <e>Wow<f>!!!</f></e></a>)",
+		var nested = new MultiStyleText("(<a>Now with <b>support</b> for <c>nesting <d>tags</d></c>!  <e>Wow<f>!!!</f></e></a>)",
 			{
 				default: { fontFamily: "Tahoma", fontSize: "24px", fill: 0x222222 },
 				a: { fill: "blue" },
@@ -53,7 +53,7 @@
 		nested.position.y = 100;
 
 		// create a text object with a nice stroke
-		var spinningText = new MultiStyleText.MultiStyleText("<iam>I'm</iam> fun<and>,</and> fun <and>and</and> fun<ding>!</ding>",
+		var spinningText = new MultiStyleText("<iam>I'm</iam> fun<and>,</and> fun <and>and</and> fun<ding>!</ding>",
 			{
 				default: { fontFamily: "Arial", fontSize: "60px", fontStyle: "bold", fill: "#cc00ff", stroke: "#fff", strokeThickness: 20 },
 				iam: { fontSize: "30px", fill: "#000" },
@@ -71,7 +71,7 @@
 		spinningText.position.y = 400 / 2;
 
 		// create a text object that will be updated..
-		var countingText = new MultiStyleText.MultiStyleText("COUNT 4EVAR: <count>0</count>",
+		var countingText = new MultiStyleText("COUNT 4EVAR: <count>0</count>",
 			{
 				default: { fontFamily: "Avro", fontSize: "60px", fontStyle: "bold italic", fill: "#3e1707" },
 				count: { fontFamily: "Avro", fontSize: "60px", fontStyle: "bold italic", fill: "#3e1707", stroke: "#a4410e", strokeThickness: 7 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
 		var stage = new PIXI.Container();
 
 		// create some white text using the Snippet webfont
-		var textSample = new MultiStyleText("<pixi>Pixi.js</pixi> can has <multiline>multiline</multiline>\nand <multistyle>multi-styles</multistyle> text!",
+		var textSample = new MultiStyleText.MultiStyleText("<pixi>Pixi.js</pixi> can has <multiline>multiline</multiline>\nand <multistyle>multi-styles</multistyle> text!",
 			{
 				default: { fontFamily: "Tahoma", fontSize: "35px", fill: "white" },
 				multiline: { fill: "blue" },
@@ -38,7 +38,7 @@
 		textSample.position.x = 20;
 		textSample.position.y = 20;
 
-		var nested = new MultiStyleText("(<a>Now with <b>support</b> for <c>nesting <d>tags</d></c>!  <e>Wow<f>!!!</f></e></a>)",
+		var nested = new MultiStyleText.MultiStyleText("(<a>Now with <b>support</b> for <c>nesting <d>tags</d></c>!  <e>Wow<f>!!!</f></e></a>)",
 			{
 				default: { fontFamily: "Tahoma", fontSize: "24px", fill: 0x222222 },
 				a: { fill: "blue" },
@@ -53,7 +53,7 @@
 		nested.position.y = 100;
 
 		// create a text object with a nice stroke
-		var spinningText = new MultiStyleText("<iam>I'm</iam> fun<and>,</and> fun <and>and</and> fun<ding>!</ding>",
+		var spinningText = new MultiStyleText.MultiStyleText("<iam>I'm</iam> fun<and>,</and> fun <and>and</and> fun<ding>!</ding>",
 			{
 				default: { fontFamily: "Arial", fontSize: "60px", fontStyle: "bold", fill: "#cc00ff", stroke: "#fff", strokeThickness: 20 },
 				iam: { fontSize: "30px", fill: "#000" },
@@ -71,7 +71,7 @@
 		spinningText.position.y = 400 / 2;
 
 		// create a text object that will be updated..
-		var countingText = new MultiStyleText("COUNT 4EVAR: <count>0</count>",
+		var countingText = new MultiStyleText.MultiStyleText("COUNT 4EVAR: <count>0</count>",
 			{
 				default: { fontFamily: "Avro", fontSize: "60px", fontStyle: "bold italic", fill: "#3e1707" },
 				count: { fontFamily: "Avro", fontSize: "60px", fontStyle: "bold italic", fill: "#3e1707", stroke: "#a4410e", strokeThickness: 7 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./pixi-multistyle-text").default;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "demo": "npm run build && open demo/index.html",
-    "build": "tsc; browserify pixi-multistyle-text.ts -p tsify -s MultiStyleText -o dist/pixi-multistyle-text.js -d",
+    "build": "tsc; browserify index.js -p tsify -s MultiStyleText -o dist/pixi-multistyle-text.js -d",
     "prepublish": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "browserify": "^13.1.1",
+    "tsify": "^2.0.7",
     "@types/pixi.js": "^4.3.1",
     "typescript": "^2.1.4"
   },
   "scripts": {
     "demo": "npm run build && open demo/index.html",
-    "build": "tsc",
+    "build": "tsc; browserify pixi-multistyle-text.ts -p tsify -s MultiStyleText -o dist/pixi-multistyle-text.js -d",
     "prepublish": "npm run build"
   }
 }

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -24,7 +24,7 @@ interface TextData {
 	fontProperties: FontProperties;
 }
 
-export class MultiStyleText extends PIXI.Text {
+export default class MultiStyleText extends PIXI.Text {
 	private textStyles: TextStyleSet;
 
 	constructor(text: string, styles: TextStyleSet) {

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -2,11 +2,11 @@
 
 "use strict";
 
-interface ExtendedTextStyle extends PIXI.TextStyleOptions {
+export interface ExtendedTextStyle extends PIXI.TextStyleOptions {
 	valign?: "top" | "middle" | "bottom";
 }
 
-interface TextStyleSet {
+export interface TextStyleSet {
 	[key: string]: ExtendedTextStyle;
 }
 
@@ -24,7 +24,7 @@ interface TextData {
 	fontProperties: FontProperties;
 }
 
-class MultiStyleText extends PIXI.Text {
+export class MultiStyleText extends PIXI.Text {
 	private textStyles: TextStyleSet;
 
 	constructor(text: string, styles: TextStyleSet) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"target": "es5",
-		"module": "none",
+		"module": "umd",
 		"moduleResolution": "node",
 		"removeComments": true,
 		"sourceMap": true,


### PR DESCRIPTION
Turns out the fix I had before was a full fix: the `.d.ts` issues I was having were due to setup errors on my end.

**EDIT: No longer has any breaking changes.**

---

_The following no longer applies.  I'm keeping it here so that the discussion below makes sense._

**Breaking change**: `MultiStyleText` is now wrapped in a module, which means that even when including this package via a `<script>` tag, you need to "unwrap" it to use it:

```js
let textSample = new MultiStyleText.MultiStyleText("It's sad, but required.");
```