### PR TITLE
[Fixes #34] Add setTagStyle() and deleteTagStyle()

### DIFF
--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -78,21 +78,10 @@ export default class MultiStyleText extends PIXI.Text {
 	}
 
 	public setTagStyle(tag: string, style: ExtendedTextStyle): void {
-		if (tag === "default") {
-			this.textStyles[tag] = this.assign(MultiStyleText.DEFAULT_TAG_STYLE, style);
-		} else {
-			this.textStyles[tag] = this.assign({}, style);
-		}
-
-		this._style = new PIXI.TextStyle(this.textStyles["default"]);
-		this.dirty = true;
-	}
-
-	public updateTagStyle(tag: string, style: ExtendedTextStyle): void {
 		if (tag in this.textStyles) {
 			this.assign(this.textStyles[tag], style);
 		} else {
-			this.setTagStyle(tag, style);
+			this.textStyles[tag] = this.assign({}, style);
 		}
 
 		this._style = new PIXI.TextStyle(this.textStyles["default"]);

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -84,11 +84,29 @@ export default class MultiStyleText extends PIXI.Text {
 			this.textStyles[tag] = this.assign({}, style);
 		}
 
+		this._style = new PIXI.TextStyle(this.textStyles["default"]);
 		this.dirty = true;
 	}
 
 	public updateTagStyle(tag: string, style: ExtendedTextStyle): void {
-		this.assign(this.textStyles[tag], style);
+		if (tag in this.textStyles) {
+			this.assign(this.textStyles[tag], style);
+		} else {
+			this.setTagStyle(tag, style);
+		}
+
+		this._style = new PIXI.TextStyle(this.textStyles["default"]);
+		this.dirty = true;
+	}
+
+	public deleteTagStyle(tag: string): void {
+		if (tag === "default") {
+			this.textStyles["default"] = this.assign({}, MultiStyleText.DEFAULT_TAG_STYLE);
+		} else {
+			delete this.textStyles[tag];
+		}
+
+		this._style = new PIXI.TextStyle(this.textStyles["default"]);
 		this.dirty = true;
 	}
 

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -25,6 +25,33 @@ interface TextData {
 }
 
 export default class MultiStyleText extends PIXI.Text {
+	private static DEFAULT_TAG_STYLE: ExtendedTextStyle = {
+		align: "left",
+		breakWords: false,
+		dropShadow: false,
+		dropShadowAngle: Math.PI / 6,
+		dropShadowBlur: 0,
+		dropShadowColor: "#000000",
+		dropShadowDistance: 5,
+		fill: "black",
+		fillGradientType: PIXI.TEXT_GRADIENT.LINEAR_VERTICAL,
+		fontFamily: "Arial",
+		fontSize: 26,
+		fontStyle: "normal",
+		fontVariant: "normal",
+		fontWeight: "normal",
+		letterSpacing: 0,
+		lineHeight: 0,
+		lineJoin: "miter",
+		miterLimit: 10,
+		padding: 0,
+		stroke: "black",
+		strokeThickness: 0,
+		textBaseline: "alphabetic",
+		wordWrap: false,
+		wordWrapWidth: 100
+	};
+
 	private textStyles: TextStyleSet;
 
 	constructor(text: string, styles: TextStyleSet) {
@@ -36,32 +63,7 @@ export default class MultiStyleText extends PIXI.Text {
 	public set styles(styles: TextStyleSet) {
 		this.textStyles = {};
 
-		this.textStyles["default"] = {
-			align: "left",
-			breakWords: false,
-			dropShadow: false,
-			dropShadowAngle: Math.PI / 6,
-			dropShadowBlur: 0,
-			dropShadowColor: "#000000",
-			dropShadowDistance: 5,
-			fill: "black",
-			fillGradientType: PIXI.TEXT_GRADIENT.LINEAR_VERTICAL,
-			fontFamily: "Arial",
-			fontSize: 26,
-			fontStyle: "normal",
-			fontVariant: "normal",
-			fontWeight: "normal",
-			letterSpacing: 0,
-			lineHeight: 0,
-			lineJoin: "miter",
-			miterLimit: 10,
-			padding: 0,
-			stroke: "black",
-			strokeThickness: 0,
-			textBaseline: "alphabetic",
-			wordWrap: false,
-			wordWrapWidth: 100
-		};
+		this.textStyles["default"] = this.assign({}, MultiStyleText.DEFAULT_TAG_STYLE);
 
 		for (let style in styles) {
 			if (style === "default") {
@@ -72,6 +74,21 @@ export default class MultiStyleText extends PIXI.Text {
 		}
 
 		this._style = new PIXI.TextStyle(this.textStyles["default"]);
+		this.dirty = true;
+	}
+
+	public setTagStyle(tag: string, style: ExtendedTextStyle): void {
+		if (tag === "default") {
+			this.textStyles[tag] = this.assign(MultiStyleText.DEFAULT_TAG_STYLE, style);
+		} else {
+			this.textStyles[tag] = this.assign({}, style);
+		}
+
+		this.dirty = true;
+	}
+
+	public updateTagStyle(tag: string, style: ExtendedTextStyle): void {
+		this.assign(this.textStyles[tag], style);
 		this.dirty = true;
 	}
 


### PR DESCRIPTION
# Current Revision

- `setTagStyle(tag: string, style: ExtendedTextStyle): void` updates the given text style by overwriting the specified fields in the existing style object with the new given values.
- `deleteTagStyle(tag: string): void` deletes the styles for the given tags.  If the tag is `default`, then the default styles are reset to their defaults.

# Original

I fixed this as discussed, but changed the method name slightly and added two other helpers:

- `setTagStyle(tag: string, style: ExtendedTextStyle): void` sets the text style object for the given tag to a copy of the given object.  If the tag is `default`, then it also adds the default values if they are missing.
- `updateTagStyle(tag: string, style: ExtendedTextStyle): void` updates the given text style by overwriting the specified fields in the existing style object with the new given values.
- `deleteTagStyle(tag: string): void` deletes the styles for the given tags.  If the tag is `default`, then the default styles are reset to their defaults.