### PR TITLE
[Fixes #26] Fix drop shadows

### DIFF
--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -295,14 +295,12 @@ export default class MultiStyleText extends PIXI.Text {
 					if (typeof dropFillStyle === "number") {
 						dropFillStyle = PIXI.utils.hex2string(dropFillStyle);
 					}
-					this.context.fillStyle = dropFillStyle;
-
-					let xShadowOffset = Math.sin(textStyle.dropShadowAngle) * textStyle.dropShadowDistance;
-					let yShadowOffset = Math.cos(textStyle.dropShadowAngle) * textStyle.dropShadowDistance;
-
-					if (textStyle.fill) {
-						this.context.fillText(text, linePositionX + xShadowOffset, linePositionY + yShadowOffset);
-					}
+					this.context.shadowColor = dropFillStyle;
+					this.context.shadowBlur = textStyle.dropShadowBlur;
+					this.context.shadowOffsetX = Math.cos(textStyle.dropShadowAngle) * textStyle.dropShadowDistance * this.resolution;
+					this.context.shadowOffsetY = Math.sin(textStyle.dropShadowAngle) * textStyle.dropShadowDistance * this.resolution;
+				} else {
+					this.context.shadowColor = "transparent";
 				}
 
 				// set canvas text styles

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -183,11 +183,11 @@ export default class MultiStyleText extends PIXI.Text {
 		let maxDistance = 0;
 		let maxBlur = 0;
 
-		for (let styleKey of Object.keys(this.textStyles)) {
+		 Object.keys(this.textStyles).forEach((styleKey) => {
 			let { dropShadowDistance, dropShadowBlur } = this.textStyles[styleKey];
 			maxDistance = Math.max(maxDistance, dropShadowDistance || 0);
 			maxBlur = Math.max(maxBlur, dropShadowBlur || 0);
-		}
+		});
 
 		return maxDistance + maxBlur;
 	}
@@ -316,12 +316,12 @@ export default class MultiStyleText extends PIXI.Text {
 		this.context.save();
 
 		// First pass: draw the shadows only
-		for (let { style, text, x, y } of drawingData) {
-			this.context.font = PIXI.Text.getFontStyle(style);
-
+		drawingData.forEach(({ style, text, x, y }) => {
 			if (!style.dropShadow) {
-				continue;
+				return; // This text doesn't have a shadow
 			}
+
+			this.context.font = PIXI.Text.getFontStyle(style);
 
 			let dropFillStyle = style.dropShadowColor;
 			if (typeof dropFillStyle === "number") {
@@ -333,12 +333,12 @@ export default class MultiStyleText extends PIXI.Text {
 			this.context.shadowOffsetY = Math.sin(style.dropShadowAngle) * style.dropShadowDistance * this.resolution;
 
 			this.context.fillText(text, x, y);
-		}
+		});
 
 		this.context.restore();
 
 		// Second pass: draw strokes and fills
-		for (let { style, text, x, y } of drawingData) {
+		drawingData.forEach(({ style, text, x, y }) => {
 			this.context.font = PIXI.Text.getFontStyle(style);
 
 			let strokeStyle = style.stroke;
@@ -371,7 +371,7 @@ export default class MultiStyleText extends PIXI.Text {
 			if (style.fill) {
 				this.context.fillText(text, x, y);
 			}
-		}
+		});
 
 		this.updateTexture();
 	}

--- a/pixi-multistyle-text.ts
+++ b/pixi-multistyle-text.ts
@@ -485,8 +485,8 @@ export default class MultiStyleText extends PIXI.Text {
 		texture.trim.x = -this._style.padding - dropShadowPadding;
 		texture.trim.y = -this._style.padding - dropShadowPadding;
 
-		texture.orig.width = texture.frame.width - (this._style.padding * 2);
-		texture.orig.height = texture.frame.height - (this._style.padding * 2);
+		texture.orig.width = texture.frame.width - (this._style.padding + dropShadowPadding) * 2;
+		texture.orig.height = texture.frame.height - (this._style.padding + dropShadowPadding) * 2;
 
 		// call sprite onTextureUpdate to update scale if _width or _height were set
 		this._onTextureUpdate();


### PR DESCRIPTION
More or less what it says on the tin:

- Drop shadows are no longer cut off.
- Drop shadows now blur properly.
- Drop shadows are no longer drawn on top of other text.
- Drop shadows now measure their angles properly.

Interestingly, this makes our version of drop shadows better than `PIXI.Text`'s, which fails both of the first two points.  Perhaps I'll file a PR on Pixi itself as well at some point...