### PR TITLE
Compatibility with PIXI v5 (PIXI.BaseTexture.setRealSize)

### DIFF
--- a/src/pixi-multistyle-text.ts
+++ b/src/pixi-multistyle-text.ts
@@ -788,8 +788,14 @@ export default class MultiStyleText extends PIXI.Text {
 		texture.baseTexture.hasLoaded = true;
 		texture.baseTexture.resolution = this.resolution;
 
-		texture.baseTexture.realWidth = this.canvas.width;
-		texture.baseTexture.realHeight = this.canvas.height;
+    if("setRealSize" in texture.baseTexture) {
+      // PIXI v5.x
+      texture.baseTexture.setRealSize(this.canvas.width, this.canvas.height);
+    } else {
+      // PIXI v4.x
+		  texture.baseTexture.realWidth = this.canvas.width;
+		  texture.baseTexture.realHeight = this.canvas.height;
+    }
 		texture.baseTexture.width = this.canvas.width / this.resolution;
 		texture.baseTexture.height = this.canvas.height / this.resolution;
 		texture.trim.width = texture.frame.width = this.canvas.width / this.resolution;


### PR DESCRIPTION
Quick fix to add compatibility for PIXI v5 as PIXI.BaseTexture.realWidth and PIXI.BaseTexture.realHeight are now getters (read-only).