### PR TITLE
Undo a renaming of ExtendedTextStyle

### DIFF
--- a/src/pixi-multistyle-text.ts
+++ b/src/pixi-multistyle-text.ts
@@ -34,14 +34,14 @@ interface TextStyle {
   wordWrapWidth?: number;
 }
 
-export interface TextStyleExtended extends TextStyle {
+export interface ExtendedTextStyle extends TextStyle {
 	valign?: "top" | "middle" | "bottom" | "baseline" | number;
 	debug?: boolean;
 	tagStyle?: "xml" | "bbcode";
 }
 
 export interface TextStyleSet {
-	[key: string]: TextStyleExtended;
+	[key: string]: ExtendedTextStyle;
 }
 
 interface FontProperties {
@@ -52,7 +52,7 @@ interface FontProperties {
 
 interface TextData {
 	text: string;
-	style: TextStyleExtended;
+	style: ExtendedTextStyle;
 	width: number;
 	height: number;
 	fontProperties: FontProperties;
@@ -61,7 +61,7 @@ interface TextData {
 
 interface TextDrawingData {
 	text: string;
-	style: TextStyleExtended;
+	style: ExtendedTextStyle;
 	x: number;
 	y: number;
 	width: number;
@@ -143,7 +143,7 @@ interface TextWithPrivateMembers extends PIXI.Text {
 }
 
 export default class MultiStyleText extends PIXI.Text {
-	private static DEFAULT_TAG_STYLE: TextStyleExtended = {
+	private static DEFAULT_TAG_STYLE: ExtendedTextStyle = {
 		align: "left",
 		breakWords: false,
 		// debug intentionally not included
@@ -241,7 +241,7 @@ export default class MultiStyleText extends PIXI.Text {
 		this.withPrivateMembers().dirty = true;
 	}
 
-	public setTagStyle(tag: string, style: TextStyleExtended): void {
+	public setTagStyle(tag: string, style: ExtendedTextStyle): void {
 		if (tag in this.textStyles) {
 			this.assign(this.textStyles[tag], style);
 		} else {
@@ -386,11 +386,11 @@ export default class MultiStyleText extends PIXI.Text {
 		return outputTextData;
 	}
 
-	private getFontString(style: TextStyleExtended): string {
+	private getFontString(style: ExtendedTextStyle): string {
 		return new PIXI.TextStyle(style).toFontString();
 	}
 
-	private createTextData(text: string, style: TextStyleExtended, tag: TagData): TextData {
+	private createTextData(text: string, style: ExtendedTextStyle, tag: TagData): TextData {
 		return {
 			text,
 			style,


### PR DESCRIPTION
This is a quick patch that undoes the renaming of ExtendedTextStyle
`ExtendedTextStyle => TextStyleExtended => ExtendedTextStyle`

I originally made that change for clarity when working with the `PIXI.TextStyle` which was loaded into the main scope of this module, but it should probably be rolled back because `ExtendedTextStyle` was an exported interface and may break existing code for no good reason.